### PR TITLE
Add Sudoku Spring Boot project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# Demo
+# Demo Repository
+
+This repository now contains a simple Spring Boot Sudoku project located in the `sudoku` directory. The project can be opened using IntelliJ IDEA.
+
+To run or test the project, use Gradle inside the `sudoku` directory:
+
+```bash
+cd sudoku
+gradle bootRun   # run the application
+gradle test      # execute tests
+```

--- a/sudoku/.gitignore
+++ b/sudoku/.gitignore
@@ -1,0 +1,3 @@
+/build/
+/.gradle/
+*~

--- a/sudoku/README.md
+++ b/sudoku/README.md
@@ -1,0 +1,15 @@
+# Sudoku Spring Boot Application
+
+This is a basic Spring Boot application that displays a welcome message for Sudoku. It can be opened in IntelliJ IDEA as a Gradle project.
+
+## Running
+
+```bash
+gradle bootRun
+```
+
+## Testing
+
+```bash
+gradle test
+```

--- a/sudoku/build.gradle
+++ b/sudoku/build.gradle
@@ -1,0 +1,27 @@
+plugins {
+    id 'org.springframework.boot' version '3.2.4'
+    id 'io.spring.dependency-management' version '1.1.3'
+    id 'java'
+}
+
+group = 'com.example'
+version = '0.0.1-SNAPSHOT'
+
+sourceCompatibility = '21'
+
+tasks.withType(JavaCompile) {
+    options.encoding = 'UTF-8'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/sudoku/settings.gradle
+++ b/sudoku/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'sudoku'

--- a/sudoku/src/main/java/com/example/sudoku/HelloController.java
+++ b/sudoku/src/main/java/com/example/sudoku/HelloController.java
@@ -1,0 +1,12 @@
+package com.example.sudoku;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HelloController {
+    @GetMapping("/")
+    public String index() {
+        return "Welcome to Sudoku";
+    }
+}

--- a/sudoku/src/main/java/com/example/sudoku/SudokuApplication.java
+++ b/sudoku/src/main/java/com/example/sudoku/SudokuApplication.java
@@ -1,0 +1,11 @@
+package com.example.sudoku;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class SudokuApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(SudokuApplication.class, args);
+    }
+}

--- a/sudoku/src/test/java/com/example/sudoku/SudokuApplicationTests.java
+++ b/sudoku/src/test/java/com/example/sudoku/SudokuApplicationTests.java
@@ -1,0 +1,12 @@
+package com.example.sudoku;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class SudokuApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+}


### PR DESCRIPTION
## Summary
- add a simple Spring Boot project for Sudoku
- document how to run the project using Gradle

## Testing
- `gradle test` *(fails: plugin could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_6846a248a918832ba52aac622deee6f9