### PR TITLE
Configure Swagger and add auth tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,27 +29,33 @@
 	<properties>
 		<java.version>21</java.version>
 	</properties>
-	<dependencies>
-                <dependency>
-                        <groupId>org.springframework.boot</groupId>
-                        <artifactId>spring-boot-starter-web</artifactId>
-                </dependency>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
 
-                <dependency>
-                        <groupId>org.springframework.boot</groupId>
-                        <artifactId>spring-boot-starter-security</artifactId>
-                </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
 
-                <dependency>
-                        <groupId>org.springframework.boot</groupId>
-                        <artifactId>spring-boot-starter-data-jpa</artifactId>
-                </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
 
-                <dependency>
-                        <groupId>com.h2database</groupId>
-                        <artifactId>h2</artifactId>
-                        <scope>runtime</scope>
-                </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.5.0</version>
+        </dependency>
 
                 <dependency>
                         <groupId>io.jsonwebtoken</groupId>

--- a/src/main/java/com/example/demo/config/OpenApiConfig.java
+++ b/src/main/java/com/example/demo/config/OpenApiConfig.java
@@ -1,0 +1,19 @@
+package com.example.demo.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+
+@Configuration
+public class OpenApiConfig {
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Demo API")
+                        .version("1.0.0")
+                        .description("Demo application with JWT authentication"));
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,3 +10,4 @@ spring.jpa.show-sql=true
 
 jwt.secret=secret-key
 jwt.expirationMs=3600000
+springdoc.swagger-ui.path=/swagger-ui.html

--- a/src/test/java/com/example/demo/AuthControllerTest.java
+++ b/src/test/java/com/example/demo/AuthControllerTest.java
@@ -1,0 +1,37 @@
+package com.example.demo;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void registerAndLogin() throws Exception {
+        String payload = "{\"username\":\"john\",\"password\":\"password\"}";
+
+        mockMvc.perform(post("/api/auth/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.token").isNotEmpty());
+
+        mockMvc.perform(post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.token").isNotEmpty());
+    }
+}


### PR DESCRIPTION
## Summary
- configure Swagger with Springdoc
- expose Swagger UI on `/swagger-ui.html`
- document API metadata in a new `OpenApiConfig`
- add integration test verifying registration and login

## Testing
- `./mvnw test -q` *(fails: Failed to fetch Maven wrapper)*
- `mvn test -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846a961cc64832bb84466b8d182c8c9